### PR TITLE
Use UTF-8 for input and output

### DIFF
--- a/icutranslit/osml10n_translit.cpp
+++ b/icutranslit/osml10n_translit.cpp
@@ -67,8 +67,18 @@ Datum osml10n_translit(PG_FUNCTION_ARGS) {
     outbuf = (char *) realloc(outbuf, bufLen + 1);
     bufLen = ustr.extract(outbuf,bufLen,NULL,status);
   }
-  outbuf[bufLen] = '\0'; 
-  
+  outbuf[bufLen] = '\0';
+
+  if (!pg_verify_mbstr(GetDatabaseEncoding(), outbuf, bufLen, true)) {
+    ereport(NOTICE,
+            (errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+             errmsg("ICU error transcribing >%s<", inbuf)));
+    free(inbuf);
+    free(outbuf);
+    delete latin_tl;
+    PG_RETURN_NULL();
+  }
+
   text *new_text = (text *) palloc(VARHDRSZ + bufLen);
   SET_VARSIZE(new_text, VARHDRSZ + bufLen);
   memcpy((void *) VARDATA(new_text), /* destination */

--- a/kanjitranscript/kanjitranscript.c
+++ b/kanjitranscript/kanjitranscript.c
@@ -59,13 +59,23 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
 
   kakasi_getopt_argv(8,kakasi_argv);
   kakasi_out=kakasi_do(normalized);
-  free(normalized);
   if (kakasi_out==NULL) {
     ereport(ERROR, (errmsg("kakasi_do failed")));
+    free(normalized);
     PG_RETURN_NULL();
   }
 
   int32_t obufLen = strlen(kakasi_out);
+
+  if (!pg_verify_mbstr(GetDatabaseEncoding(), kakasi_out, obufLen, true)) {
+    ereport(NOTICE,
+            (errcode(ERRCODE_CHARACTER_NOT_IN_REPERTOIRE),
+             errmsg("kakasi error transcribing >%s<", normalized)));
+    kakasi_free(kakasi_out);
+    free(normalized);
+    PG_RETURN_NULL();
+  }
+  free(normalized);
 
   text *new_text = (text *) palloc(VARHDRSZ + obufLen);
   SET_VARSIZE(new_text, VARHDRSZ + obufLen);

--- a/kanjitranscript/kanjitranscript.c
+++ b/kanjitranscript/kanjitranscript.c
@@ -60,8 +60,8 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   kakasi_getopt_argv(8,kakasi_argv);
   kakasi_out=kakasi_do(normalized);
   if (kakasi_out==NULL) {
-    ereport(ERROR, (errmsg("kakasi_do failed")));
     free(normalized);
+    ereport(ERROR, (errmsg("kakasi_do failed")));
     PG_RETURN_NULL();
   }
 

--- a/kanjitranscript/kanjitranscript.c
+++ b/kanjitranscript/kanjitranscript.c
@@ -16,9 +16,7 @@ Licence AGPL http://www.gnu.org/licenses/agpl-3.0.de.html
 #include <libkakasi.h>
 #include <mb/pg_wchar.h>
 #include <fmgr.h>
-#include <iconv.h>
 #include <utf8proc.h>
-#include <wchar.h>
 #include "varatt.h"
 
 #ifdef PG_MODULE_MAGIC
@@ -27,40 +25,30 @@ PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(osml10n_kanji_transcript);
 
-static int utf8_strlen(char *s) {
-  int i = 0, j = 0;
-  while (s[i]) {
-    if ((s[i] & 0xc0) != 0x80) j++;
-    i++;
-  }
-  return j;
-}
-
 Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   char *inbuf;
   char *normalized;
-  wchar_t *normalized_wc;
-  size_t numchars;
-  unsigned i;
   char *kakasi_out;
-  char *kakasi_argv[6]={"kakasi","-Ja","-Ha","-Ka","-Ea","-s"};
-  
+  // Invoke kakasi in UTF-8 mode. The older EUC-JP path misromanized some
+  // characters (e.g. the kokuji 糀) and leaked EUC-JP lead bytes into the
+  // output, producing invalid UTF-8 downstream.
+  char *kakasi_argv[8]={"kakasi","-iutf8","-outf8","-Ja","-Ha","-Ka","-Ea","-s"};
+
   if (GetDatabaseEncoding() != PG_UTF8) {
     ereport(ERROR,(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
     errmsg("requires UTF8 database encoding")));
     PG_RETURN_NULL();
   }
-   
+
   text *t = PG_GETARG_TEXT_P(0);
 
   inbuf=(char *) malloc((VARSIZE(t) - VARHDRSZ +1)*sizeof(char));
   memcpy(inbuf, (void *) VARDATA(t), VARSIZE(t) - VARHDRSZ);
   inbuf[VARSIZE(t) - VARHDRSZ]='\0';
-  
-  // 1. Use Normalization Form KC to avoid Enclosed CJK Letters like
+
+  // Use Normalization Form KC to fold compatibility characters like
+  // ㈱ PARENTHESIZED IDEOGRAPH STOCK into their base forms before romanizing.
   // https://en.wikipedia.org/wiki/Enclosed_CJK_Letters_and_Months
-  // which are unavailabe in EUC-JP encoding
-  // Example: ㈱ PARENTHESIZED IDEOGRAPH STOCK
   normalized=utf8proc_NFKC(inbuf);
   if (NULL == normalized) {
     ereport(ERROR, (errmsg("error calling utf8proc_NFKC")));
@@ -68,82 +56,17 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
     PG_RETURN_NULL();
   }
   free(inbuf);
-  
-  // 2. convert utf-8 to wchar
-  // This is likely not verry portable to anything else
-  // than GNU/Linux :)
-  // numchars is number of normalized unicode characters
-  numchars=mbstowcs(NULL,normalized,0);
-  normalized_wc=malloc((numchars+1)*sizeof(wchar_t));
-  mbstowcs(normalized_wc,normalized,numchars+1);
-  free(normalized);
-  
-  // 3. convert encoding to euc-jp to make it usable for kakasi
-  // do this character by character and ignore haracters where
-  // conversion failed
-  
-  // create transcoder from wchar to EUC-JP
-  iconv_t wc2euc = iconv_open("EUC-JP", "WCHAR_T");
-  if(wc2euc == (iconv_t) -1) {
-      ereport(ERROR, (errmsg("iconv Initialization failure")));
-      PG_RETURN_NULL();
-  }
-   
-  // len of wchar
-  size_t ibl = numchars*sizeof(wchar_t);;
-  // len of eucjp is maximum 3 bytes per char + 0-terminator
-  size_t obl =  numchars*3+1;
-  size_t clen_in = sizeof(wchar_t);
-  size_t clen_out = sizeof(wchar_t);
-         
-  char *converted = calloc(obl, sizeof(char));
-  char *converted_start = converted;
-  char *single_euc = calloc(4, sizeof(char));
-  char *single_euc_start = single_euc;
-  
-  // convert wchat to eucjp
-  // do this character by character and ignore
-  // characters where conversion failed  
-  char *iconv_in;
-  size_t euclen; 
-  for (i=0;i<wcslen(normalized_wc);i++) {
-    iconv_in = (char *)&normalized_wc[i];
-    clen_in = clen_out = sizeof(wchar_t);
-    int ret = iconv(wc2euc,&iconv_in,&clen_in, &single_euc, &clen_out);
-    // copy EUC-JP character to output if conversion succeeded
-    if(ret != (size_t) -1) {
-      euclen=sizeof(wchar_t)-clen_out;
-      memcpy(converted,single_euc_start,euclen);
-      converted+=euclen;
-    }
-    single_euc=single_euc_start;
-  }
-  // 0-terminate EUC-JP string
-  converted='\0';
-  free(single_euc_start);  
-  iconv_close(wc2euc);
-  free(normalized_wc);
 
-  // EUC-JP string is empty
-  if (strlen(converted_start)==0) {
-    free(converted_start);
-    PG_RETURN_NULL();
-  }
-  
-  // 4. run kakasi transliteration
-  
-  // run kakasi on eucjp string
-  kakasi_getopt_argv(6,kakasi_argv);
-  kakasi_out=kakasi_do(converted_start);
-  free(converted_start);
+  kakasi_getopt_argv(8,kakasi_argv);
+  kakasi_out=kakasi_do(normalized);
+  free(normalized);
   if (kakasi_out==NULL) {
     ereport(ERROR, (errmsg("kakasi_do failed")));
     PG_RETURN_NULL();
   }
-  
-  // 5. write kakasi output to psql buffer        
+
   int32_t obufLen = strlen(kakasi_out);
-  
+
   text *new_text = (text *) palloc(VARHDRSZ + obufLen);
   SET_VARSIZE(new_text, VARHDRSZ + obufLen);
   memcpy((void *) VARDATA(new_text), /* destination */

--- a/kanjitranscript/kanjitranscript.c
+++ b/kanjitranscript/kanjitranscript.c
@@ -25,14 +25,27 @@ PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(osml10n_kanji_transcript);
 
+void _PG_init(void);
+
+void _PG_init(void) {
+  // Invoke kakasi in UTF-8 mode. The older EUC-JP path misromanized some
+  // characters (e.g. the kokuji 糀) and leaked EUC-JP lead bytes into the
+  // output, producing invalid UTF-8 downstream.
+  //
+  // kakasi_getopt_argv must be called exactly once per process: it opens
+  // the kanwa/itaiji dictionaries and an iconv descriptor for the internal
+  // EUC-JP <-> UTF-8 conversion. Calling it per-invocation leaks FILE
+  // handles and iconv descriptors, eventually corrupting libkakasi's
+  // static state — observed as silent empty output and, for some inputs,
+  // an infinite loop in the dictionary scan (perf top: _IO_getc + iconv).
+  static char *kakasi_argv[8]={"kakasi","-iutf8","-outf8","-Ja","-Ha","-Ka","-Ea","-s"};
+  kakasi_getopt_argv(8, kakasi_argv);
+}
+
 Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   char *inbuf;
   char *normalized;
   char *kakasi_out;
-  // Invoke kakasi in UTF-8 mode. The older EUC-JP path misromanized some
-  // characters (e.g. the kokuji 糀) and leaked EUC-JP lead bytes into the
-  // output, producing invalid UTF-8 downstream.
-  char *kakasi_argv[8]={"kakasi","-iutf8","-outf8","-Ja","-Ha","-Ka","-Ea","-s"};
 
   if (GetDatabaseEncoding() != PG_UTF8) {
     ereport(ERROR,(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -57,7 +70,6 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   }
   free(inbuf);
 
-  kakasi_getopt_argv(8,kakasi_argv);
   kakasi_out=kakasi_do(normalized);
   if (kakasi_out==NULL) {
     free(normalized);


### PR DESCRIPTION
Use UTF-8 for input and output in libkakasi to prevent invalid UTF-8  sequences that are possible in EUC-JP.